### PR TITLE
Making cards look more like the originals

### DIFF
--- a/mirror_api_server/static/glass/glass.css
+++ b/mirror_api_server/static/glass/glass.css
@@ -6,22 +6,23 @@
 }
 
 body {
-  background-color: black;
+  background-color: #222;
   width: 100%;
 }
 
 .card {
   font-family: "Roboto", Arial, sans-serif;
-  font-weight: 300;
+  font-weight: 100;
   color: rgba(255,255,255,0.8);
   display: inline-block;
   margin-left: 10px;
   margin-right: 10px;
   width: 640px;
-  height: 400px;
-  background-color: #444;
+  height: 360px;
+  background-color: #000;
   position: relative;
   padding: 0;
+  text-shadow: 0 1px 0px rgba(0,0,0,0.8);
   white-space: normal;
   overflow: hidden;
 }
@@ -29,13 +30,43 @@ body {
 .card_text {
   position: absolute;
   top: 10px; left: 20px;
-  font-size: 5em;
+  font-size: 4.5em;
 }
 
 .card_date {
+	bottom: 0;
+  font-size: 1.5em;
+  padding: 40px;
   position: absolute;
-  font-size: 2em;
-  bottom: 10px; right: 10px;
+  text-align: right;
+  width: 100%;
+}
+
+
+/** Card-type-specific Styles */
+
+.card_type_image {
+	background-size: cover;
+}
+
+.card_type_image > .card_text {
+	background-color: rgba(0,0,0,0.4);
+	font-size: 2.4em;
+	font-style: italic;
+	height: 100%;
+	left: 0;
+	padding: 10px 20px;
+	top: 0;
+	width: 100%;
+}
+
+.card_type_image > .card_date {
+	background-image: linear-gradient(bottom, rgba(0,0,0,0.7), transparent 100%);
+	background-image: -o-linear-gradient(bottom, rgba(0,0,0,0.7), transparent 100%);
+	background-image: -moz-linear-gradient(bottom, rgba(0,0,0,0.7), transparent 100%);
+	background-image: -webkit-linear-gradient(bottom, rgba(0,0,0,0.7), transparent 100%);
+	background-image: -ms-linear-gradient(bottom, rgba(0,0,0,0.7), transparent 100%);
+	padding: 15px 25px;
 }
 
 #signin, #signout {

--- a/mirror_api_server/static/glass/glass.js
+++ b/mirror_api_server/static/glass/glass.js
@@ -45,38 +45,35 @@
       this.date = new Date(date);
       this.image = image;
 
-      function loadImage() {
-        cardDiv.style.backgroundImage = "url(" + image + ")";
-        cardDiv.style.backgroundSize = "640px";
-        textDiv.style.fontSize = "3em";
-        textDiv.style.backgroundColor = "rgba(0,0,0,0.3)";
-        dateDiv.style.backgroundColor = "rgba(0,0,0,0.3)";
+      this.loadImage = function () {
+        this.cardDiv.style.backgroundImage = "url(" + image + ")";
       }
-      
+
       this.createDiv = function () {
         var tmpDiv;
         tmpDiv = doc.createElement("div");
         tmpDiv.classList.add("card");
         tmpDiv.id = "c" + id;
 
-        cardDiv = tmpDiv;
+        this.cardDiv = tmpDiv;
 
         tmpDiv = doc.createElement("div");
         tmpDiv.classList.add("card_text");
         tmpDiv.appendChild(doc.createTextNode(this.text));
         textDiv = tmpDiv;
-        cardDiv.appendChild(textDiv);
+        this.cardDiv.appendChild(textDiv);
         tmpDiv = doc.createElement("div");
         tmpDiv.classList.add("card_date");
         tmpDiv.appendChild(doc.createTextNode(this.date.niceDate()));
         dateDiv = tmpDiv;
-        cardDiv.appendChild(dateDiv);
+        this.cardDiv.appendChild(dateDiv);
 
         if (this.image) {
-          loadImage();
+          this.loadImage();
         }
-        
-        return cardDiv;
+
+        this.updateCardType();
+        return this.cardDiv;
       };
 
       this.updateText = function (text) {
@@ -103,7 +100,7 @@
         if (this.image !== image) {
           if (image) {
             this.image = image;
-            loadImage();
+            this.loadImage();
           } else {
             this.image = undefined;
             cardDiv.style.backgroundImage = "none";
@@ -118,6 +115,18 @@
         dateDiv.innerHTML = "";
         dateDiv.appendChild(doc.createTextNode(this.date.niceDate()));
       };
+
+      this.updateCardType = function () {
+        // Reset type
+        this.cardDiv.className = 'card';
+
+        if (!!this.image) {
+          this.cardDiv.classList.add('card_type_image');
+        } else {
+          this.cardDiv.classList.add('card_type_text');
+          // And in the future possibly also card_type_html
+        }
+      }
 
       this.getDiv = function () { return cardDiv; };
     }
@@ -165,6 +174,7 @@
                 }
               }
               card.updateImage(result.items[i].image);
+              card.updateCardType();
             } else {
               card = new Card(result.items[i].id, result.items[i].text, result.items[i].when, result.items[i].image);
               cards.push(card);

--- a/mirror_api_server/templates/glass.html
+++ b/mirror_api_server/templates/glass.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Glass</title>
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:100,300,500">
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:100,100italic,300,500">
     <link rel="stylesheet" type="text/css" href="glass.css">
     <script src="glass.js"></script>
   </head>


### PR DESCRIPTION
Moving custom styling from JS to CSS.
Introducing type-specific card type CSS classes for that (`card_type_text`, `card_type_image`, possibly in the future `card_type_html`).

The style has been adjusted to correspond to the demo cards shown in
the Glass Talk at SXSW. In particular, I have:
- Slightly reduced the Card height
- Used the Ultra Light font variant
- Adjusted the padding of the date stamp
- Added a slight text shadow
- Adjusted the text font style for image cards

Here's a screenshot for comparison, the bottom ones are cropped from the SXSW slides:
![Screen Shot 2013-04-05 at 6 15 12 PM](https://f.cloud.github.com/assets/811803/344914/989ce27e-9e0f-11e2-8ea2-ae072141f68b.png)

Feel free to ignore this pull request if you don't like the style updates ;-)
