### PR TITLE
Minor improvements in `createDiv()`

### DIFF
--- a/mirror_api_server/static/glass/glass.js
+++ b/mirror_api_server/static/glass/glass.js
@@ -434,54 +434,50 @@
       }
 
       function createDiv() {
-        var tmpDiv;
+        cardDiv = doc.createElement("div");
+        cardDiv.id = "c" + id;
+
         switch (type) {
         case START_CARD:
-          cardDiv = doc.createElement("div");
-          cardDiv.id = "c" + id;
           cardDiv.innerHTML = templates.start;
           mainDiv.appendChild(cardDiv);
           break;
         case CLOCK_CARD:
-          cardDiv = doc.createElement("div");
-          cardDiv.id = "c" + id;
           cardDiv.innerHTML = templates.normal;
           mainDiv.appendChild(cardDiv);
           textDiv = doc.querySelector("#" + cardDiv.id + " .card_text");
+          textDiv = cardDiv.querySelector(".card_text");
           textDiv.appendChild(doc.createTextNode("\"ok glass\""));
           dateDiv = doc.querySelector("#" + cardDiv.id + " .card_date");
+          dateDiv = cardDiv.querySelector(".card_date");
           dateDiv.appendChild(doc.createTextNode((new Date()).formatTime()));
           break;
         case CONTENT_CARD:
-          cardDiv = doc.createElement("div");
-          cardDiv.id = "c" + id;
           cardDiv.innerHTML = templates.normal;
           mainDiv.appendChild(cardDiv);
-          textDiv = doc.querySelector("#" + cardDiv.id + " .card_text");
+          textDiv = cardDiv.querySelector(".card_text");
           textDiv.appendChild(doc.createTextNode(that.text));
-          dateDiv = doc.querySelector("#" + cardDiv.id + " .card_date");
+          dateDiv = cardDiv.querySelector(".card_date");
           dateDiv.appendChild(doc.createTextNode(that.date.niceDate()));
           if (that.image) {
             loadImage();
           }
           break;
         case ACTION_CARD:
-          cardDiv = doc.createElement("div");
-          cardDiv.id = "c" + id;
           cardDiv.innerHTML = templates.action;
           mainDiv.appendChild(cardDiv);
-          textDiv = doc.querySelector("#" + cardDiv.id + " .card_text");
+          textDiv = cardDiv.querySelector(".card_text");
           if (!!actions[that.action]) {
             textDiv.appendChild(doc.createTextNode(actions[that.action].values[0].displayName));
-            doc.querySelector("#" + cardDiv.id + " .card_icon").src = actions[that.action].values[0].iconUrl;
+            cardDiv.querySelector(".card_icon").src = actions[that.action].values[0].iconUrl;
           } else {
             textDiv.appendChild(doc.createTextNode(data.values[0].displayName));
-            doc.querySelector("#" + cardDiv.id + " .card_icon").src = data.values[0].iconUrl;
+            cardDiv.querySelector(".card_icon").src = data.values[0].iconUrl;
           }
           break;
         }
 
-        interfaceDiv = doc.querySelector("#" + cardDiv.id + " .card_interface");
+        interfaceDiv = cardDiv.querySelector(".card_interface");
         that.updateCardStyle();
         that.hide();
       }


### PR DESCRIPTION
Just as an FYI, `querySelector` can be used in a scoped manner as well ;-) 

This avoids having to add the parent ID all the time. See also [`Element.querySelector` (MDN)](https://developer.mozilla.org/en-US/docs/DOM/Element.querySelector#Browser_compatibility), it's just as compatible as `document.querySelector`.

Also moved the common `cardDiv` creation outside the `switch` statement, as this is completely type independent & a necessary action (but in general I think using a proper templating engine would make the code even cleaner, if you want I can take a look at that).
